### PR TITLE
46: fix routing

### DIFF
--- a/app/controllers/public_controller.rb
+++ b/app/controllers/public_controller.rb
@@ -1,5 +1,5 @@
 class PublicController < ApplicationController
   def index
-    render file: Rails.public_path.join('public', 'index.html'), layout: false
+    render file: Rails.public_path.join('index.html'), layout: false
   end
 end

--- a/app/controllers/public_controller.rb
+++ b/app/controllers/public_controller.rb
@@ -1,0 +1,5 @@
+class PublicController < ApplicationController
+  def index
+    render file: Rails.public_path.join('public', 'index.html'), layout: false
+  end
+end

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,5 +1,5 @@
 class StaticController < ApplicationController
   def index
-    render file: Rails.public_path.join('public', 'index.html'), layout: false
+    render file: Rails.public_path.join('index.html'), layout: false
   end
 end

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,5 +1,0 @@
-class StaticController < ApplicationController
-  def index
-    render file: Rails.public_path.join('index.html'), layout: false
-  end
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,6 @@ Rails.application.routes.draw do
     # get '*path', to: 'static#index', constraints: lambda { |req|
     #   req.path.exclude?('rails/active_storage') && !req.path.blank?
     # }
-    get '*path', to: static('index.html')
-    # post '*path', to: static('index.html')
+    get '*path', to: 'public#index', constraints: ->(request) { !request.xhr? && request.format.html? }
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,9 +21,6 @@ Rails.application.routes.draw do
   root 'public#index'
   # The env var is for testing in development.
   if ENV['RAILS_SERVE_STATIC_FILES'].present? || Rails.env.production?
-    # get '*path', to: 'static#index', constraints: lambda { |req|
-    #   req.path.exclude?('rails/active_storage') && !req.path.blank?
-    # }
     get '*path', to: 'public#index', constraints: ->(request) { !request.xhr? && request.format.html? }
   end
 end


### PR DESCRIPTION
closes #46 

Use the correct controller and update the path helper to allow for going directly to the react routes.